### PR TITLE
Make sure python gets signals

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /app
 COPY requirements.txt ./requirements.txt
 RUN pip3 install -r requirements.txt
 COPY . .
-CMD streamlit run app.py
+CMD ["streamlit", "run", "app.py"]


### PR DESCRIPTION
This makes it possible to stop the running Docker container by pressing
Ctl-C, which isn't possible using the single string format for CMD